### PR TITLE
Bump deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,14 +2,14 @@ version: 2
 updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/.github"
     schedule:
       interval: "daily"
     target-branch: "dev"
 
   # Maintain dependencies for Go mods
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/src"
     schedule:
       interval: "daily"
     target-branch: "dev"

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,7 @@
 #
 --trusted-host pypi.org
 
-apscheduler==3.8.1
+apscheduler==3.9.0.post1
     # via -r requirements.in
 backports.zoneinfo==0.2.1
     # via

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.10
     # via requests
 idna==3.3
     # via requests
-python-decouple==3.5
+python-decouple==3.6
     # via -r requirements.in
 pytz==2021.3
     # via apscheduler


### PR DESCRIPTION
bump deps:
1. Bump apscheduler from 3.8.1 to 3.9.0.post1
2. Bump python-decouple from 3.5 to 3.6

Other:
1. Update directory for dependabot